### PR TITLE
Commented creating outputtext instead of outputlabel

### DIFF
--- a/modules/faces/core/src/main/java/org/metawidget/faces/renderkit/html/HtmlLayoutRenderer.java
+++ b/modules/faces/core/src/main/java/org/metawidget/faces/renderkit/html/HtmlLayoutRenderer.java
@@ -167,7 +167,7 @@ public abstract class HtmlLayoutRenderer
 	 */
         protected UIOutput createLabel( FacesContext context, UIComponent componentNeedingLabel ) {
                 // Don't create h:outputlabel for not UIInput components
-                // as it will cause warnings in log (at least in Glassfish 3.1.1)
+                // as label are supposed to be for input elements.
                 if ((componentNeedingLabel instanceof UIInput) && !(componentNeedingLabel instanceof UIMetawidget)) {
                         HtmlOutputLabel componentLabel = 
                                 (HtmlOutputLabel) context.getApplication().createComponent( "javax.faces.HtmlOutputLabel" );


### PR DESCRIPTION
And also created separate branch for this feature to simplify further pulls.
Labels for faces components will be created as simple outputtext if target is not instance UIInput.
