### PR TITLE
Fixing a NPE when using the GroovyPropertyStyle with the traditional way of using HTML Widget Tags

### DIFF
--- a/modules/groovy/src/main/java/org/metawidget/inspector/impl/propertystyle/groovy/GroovyPropertyStyle.java
+++ b/modules/groovy/src/main/java/org/metawidget/inspector/impl/propertystyle/groovy/GroovyPropertyStyle.java
@@ -84,6 +84,11 @@ public class GroovyPropertyStyle
 		// Iterate over all Groovy properties
 
 		Class<?> clazz = ClassUtils.niceForName( type );
+
+		if ( clazz == null ) {
+			return propertiesToReturn;
+		}
+		
 		List<MetaProperty> properties = GroovySystem.getMetaClassRegistry().getMetaClass( clazz ).getProperties();
 
 		for ( MetaProperty property : properties ) {

--- a/modules/groovy/src/test/java/org/metawidget/inspector/impl/propertystyle/groovy/GroovyPropertyStyleTest.java
+++ b/modules/groovy/src/test/java/org/metawidget/inspector/impl/propertystyle/groovy/GroovyPropertyStyleTest.java
@@ -80,4 +80,10 @@ public class GroovyPropertyStyleTest
 		Map<String, Property> properties = propertyStyle.getProperties( byte[].class.getName() );
 		assertTrue( properties.isEmpty() );
 	}
+
+	public void testIgnoreInvalidTypes() {
+		GroovyPropertyStyle propertyStyle = new GroovyPropertyStyle();
+		Map<String, Property> properties = propertyStyle.getProperties( "invalid" );
+		assertTrue( properties.isEmpty() );
+	}
 }


### PR DESCRIPTION
...ng Class<?> arguments to String arguments

Groovy was affected as the Groovy compiler will throw a NPE if passed a null argument.
