### PR TITLE
initNestedMetawidget for StaticSpringMetawidget

### DIFF
--- a/modules/static/spring/core/src/main/java/org/metawidget/statically/spring/StaticSpringMetawidget.java
+++ b/modules/static/spring/core/src/main/java/org/metawidget/statically/spring/StaticSpringMetawidget.java
@@ -16,12 +16,15 @@
 
 package org.metawidget.statically.spring;
 
+import static org.metawidget.inspector.InspectionResultConstants.NAME;
+
 import java.util.Map;
 
 import org.metawidget.statically.StaticMetawidget;
 import org.metawidget.statically.jsp.StaticJspMetawidget;
 import org.metawidget.statically.jsp.StaticJspUtils;
 import org.metawidget.util.ClassUtils;
+import org.metawidget.util.simple.StringUtils;
 
 /**
  * @author Richard Kennard
@@ -37,10 +40,10 @@ public class StaticSpringMetawidget
     @Override
     public void initNestedMetawidget( StaticMetawidget nestedMetawidget, Map<String, String> attributes ) {
 
-        if ( ((StaticJspMetawidget) nestedMetawidget).getValue() != null ) {
-            String valueExpression = ((StaticJspMetawidget) nestedMetawidget).getValue();
-            valueExpression = StaticJspUtils.unwrapExpression(valueExpression);
-            ((StaticJspMetawidget) nestedMetawidget).setValue(valueExpression);
+        if ( ( (StaticJspMetawidget) nestedMetawidget ).getValue() != null ) {
+            String valueExpression = StaticJspUtils.unwrapExpression( getValue() );
+            valueExpression += StringUtils.SEPARATOR_DOT_CHAR + attributes.get(NAME);
+            ( (StaticJspMetawidget) nestedMetawidget ).setValue(valueExpression);
         }
 
         super.initNestedMetawidget(nestedMetawidget, attributes);


### PR DESCRIPTION
Hi Richard,

I've added an initNestedMetawidget method for StaticSpringMetawigdet.  I think that it is necessary because, as it now stands, if the nested metawidget has no set value, the StaticJspMetawidget initNestedMetawidget method will set one for it, which will be wrapped using the JSP EL.  This creates problems with Spring as, when processed by its PathProcessor, widgets are left with a path like path="name}.id", as the PathProcessor looks for the first instance of the '.' character.  The initNestedMetawidget method that I created determines the value in the exact same method as the StaticJspMetawidget method, it just does not wrap it.  Let me know if you have any questions or concerns, as usual.

Cheers,
Ryan
