### PR TITLE
Update metawidget-angular.js

### DIFF
--- a/modules/js/angularjs/src/main/webapp/lib/metawidget/angular/metawidget-angular.js
+++ b/modules/js/angularjs/src/main/webapp/lib/metawidget/angular/metawidget-angular.js
@@ -379,7 +379,7 @@ var metawidget = metawidget || {};
 		this.buildNestedMetawidget = function( attributes, config ) {
 
 			var nestedMetawidget = metawidget.util.createElement( this, 'metawidget' );
-			nestedMetawidget.setAttribute( 'ng-model', attrs.ngModel + '.' + attributes.name );
+			nestedMetawidget.setAttribute( 'ng-model', attrs.ngModel + (attributes.name[0]=='[' ? '' : '.' )+ attributes.name );
 			if ( metawidget.util.isTrueOrTrueString( attributes.readOnly ) ) {
 				nestedMetawidget.setAttribute( 'read-only', 'true' );
 			} else if ( attrs.readOnly !== undefined ) {


### PR DESCRIPTION
In line 382, modified then ng-model attribute generation to account for the case when the attribute name starts with "[".
For example "[2].name"
Previously it always added a dot in front of the name so in case of an array it generated invalid attributes like:
"person.[2].name" which resulted in empty input boxes.
