### PR TITLE
upgrade Vaadin to 7.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -734,25 +734,25 @@
 			<dependency>
 				<groupId>com.vaadin</groupId>
 				<artifactId>vaadin-client</artifactId>
-				<version>7.0.3</version>
+				<version>7.3.2</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>com.vaadin</groupId>
 				<artifactId>vaadin-server</artifactId>
-				<version>7.0.3</version>
+				<version>7.3.2</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>com.vaadin</groupId>
 				<artifactId>vaadin-themes</artifactId>
-				<version>7.0.3</version>
+				<version>7.3.2</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>com.vaadin</groupId>
 				<artifactId>vaadin-client-compiled</artifactId>
-				<version>7.0.3</version>
+				<version>7.3.2</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Resolves #25 

All Vaadin 7 (modules/java/vaadin/core) tests pass. The built JAR works in my application without getting the exception stated in #25 
