### PR TITLE
Nested UIMetawidgets do not inherit buildWidgetsOnAjaxRequest flag

### DIFF
--- a/modules/java/faces/core/src/main/java/org/metawidget/faces/component/UIMetawidget.java
+++ b/modules/java/faces/core/src/main/java/org/metawidget/faces/component/UIMetawidget.java
@@ -743,6 +743,10 @@ public abstract class UIMetawidget
 		// the attributes map as a storage area for special flags (eg.
 		// ComponentSupport.MARK_CREATED) that should not get copied down from component to
 		// component!
+		
+		// AJAX
+		
+		nestedMetawidget.setBuildWidgetsOnAjaxRequest(mBuildWidgetsOnAjaxRequest);
 	}
 
 	@Override


### PR DESCRIPTION
If a metawidget is built for a bean containing nested beans, only the first level of widgets can be refreshed through AJAX because the buildWidgetsOnAjaxRequest setting from the root metawidget is not passed to its nested metawidgets.