### PR TITLE
Trivial Fork of JakartaJpa module from old (javax) Jpa module.

### DIFF
--- a/modules/java/jakartajpa/.gitignore
+++ b/modules/java/jakartajpa/.gitignore
@@ -1,0 +1,2 @@
+.idea
+target

--- a/modules/java/jakartajpa/pom.xml
+++ b/modules/java/jakartajpa/pom.xml
@@ -1,0 +1,45 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<parent>
+		<groupId>org.metawidget.modules</groupId>
+		<artifactId>modules-java-parent</artifactId>
+		<version>4.3-SNAPSHOT</version>
+		<relativePath>../</relativePath>
+	</parent>
+    <properties>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
+    </properties>
+    <modelVersion>4.0.0</modelVersion>
+
+	<artifactId>metawidget-jakartajpa</artifactId>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.metawidget.modules</groupId>
+			<artifactId>metawidget-core</artifactId>
+			<version>${project.version}</version><!--$NO-MVN-MAN-VER$-->
+		</dependency>
+
+		<dependency>
+			<groupId>org.metawidget.modules</groupId>
+			<artifactId>metawidget-core</artifactId>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Jakarta JPA -->
+		<dependency>
+			<groupId>jakarta.persistence</groupId>
+			<artifactId>jakarta.persistence-api</artifactId>
+			<version>3.2.0</version>
+		</dependency> 
+
+		<!-- "Test early and often -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/modules/java/jakartajpa/src/main/java/org/metawidget/inspector/jakartajpa/JakartaJpaInspector.java
+++ b/modules/java/jakartajpa/src/main/java/org/metawidget/inspector/jakartajpa/JakartaJpaInspector.java
@@ -1,0 +1,171 @@
+// Metawidget
+//
+// This file is dual licensed under both the LGPL
+// (http://www.gnu.org/licenses/lgpl-2.1.html) and the EPL
+// (http://www.eclipse.org/org/documents/epl-v10.php). As a
+// recipient of Metawidget, you may choose to receive it under either
+// the LGPL or the EPL.
+//
+// Commercial licenses are also available. See http://metawidget.org
+// for details.
+
+package org.metawidget.inspector.jakartajpa;
+
+import static org.metawidget.inspector.InspectionResultConstants.*;
+
+import java.util.Map;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.Transient;
+import jakarta.persistence.Version;
+
+import org.metawidget.inspector.impl.BaseObjectInspector;
+import org.metawidget.inspector.impl.propertystyle.Property;
+import org.metawidget.util.CollectionUtils;
+
+/**
+ * Inspects annotations defined by Java Persistence API (JPA).
+ *
+ * @author <a href="http://kennardconsulting.com">Richard Kennard</a>
+ */
+
+public class JakartaJpaInspector
+	extends BaseObjectInspector {
+
+	//
+	// Private members
+	//
+
+	private final boolean	mHideIds;
+
+	private final boolean	mHideVersions;
+
+	private final boolean	mHideTransients;
+
+	//
+	// Constructor
+	//
+
+	public JakartaJpaInspector() {
+
+		this( new JakartaJpaInspectorConfig() );
+	}
+
+	public JakartaJpaInspector( JakartaJpaInspectorConfig config ) {
+
+		super( config );
+
+		mHideIds = config.isHideIds();
+		mHideVersions = config.isHideVersions();
+		mHideTransients = config.isHideTransients();
+	}
+
+	//
+	// Protected methods
+	//
+
+	@Override
+	protected Map<String, String> inspectProperty( Property property )
+		throws Exception {
+
+		Map<String, String> attributes = CollectionUtils.newHashMap();
+
+		// Large
+
+		if ( property.isAnnotationPresent( Lob.class ) ) {
+			attributes.put( LARGE, TRUE );
+		}
+
+		// Required
+
+		Column column = property.getAnnotation( Column.class );
+
+		if ( column != null ) {
+			if ( !column.nullable() ) {
+				attributes.put( REQUIRED, TRUE );
+			}
+
+			// Length
+			//
+			// Note: the default is 255. It is tempting to enforce this as MAXIMUM_LENGTH anyway,
+			// given that otherwise data may get silently truncated, but that doesn't work very
+			// well because not every JPA property will be annotated @Column
+
+			if ( column.length() != 255 ) {
+				attributes.put( MAXIMUM_LENGTH, String.valueOf( column.length() ) );
+			}
+		}
+
+		OneToOne oneToOne = property.getAnnotation( OneToOne.class );
+
+		if ( oneToOne != null ) {
+
+			if ( !oneToOne.optional() ) {
+				attributes.put( REQUIRED, TRUE );
+			}
+
+			String mappedBy = oneToOne.mappedBy();
+
+			if ( !"".equals( mappedBy ) ) {
+				attributes.put( INVERSE_RELATIONSHIP, mappedBy );
+			}
+		}
+
+		OneToMany oneToMany = property.getAnnotation( OneToMany.class );
+
+		if ( oneToMany != null ) {
+
+			String mappedBy = oneToMany.mappedBy();
+
+			if ( !"".equals( mappedBy ) ) {
+				attributes.put( INVERSE_RELATIONSHIP, mappedBy );
+			}
+		}
+
+		ManyToOne manyToOne = property.getAnnotation( ManyToOne.class );
+
+		if ( manyToOne != null && !manyToOne.optional() ) {
+			attributes.put( REQUIRED, TRUE );
+		}
+
+		// Hidden
+
+		if ( mHideIds && property.isAnnotationPresent( Id.class ) ) {
+			attributes.put( HIDDEN, TRUE );
+		} else if ( mHideIds && property.isAnnotationPresent( EmbeddedId.class ) ) {
+			attributes.put( HIDDEN, TRUE );
+		} else if ( mHideVersions && property.isAnnotationPresent( Version.class ) ) {
+			attributes.put( HIDDEN, TRUE );
+		} else if ( mHideTransients && property.isAnnotationPresent( Transient.class ) ) {
+			attributes.put( HIDDEN, TRUE );
+		}
+
+		// Temporal
+
+		Temporal temporal = property.getAnnotation( Temporal.class );
+		if ( temporal != null ) {
+			switch ( temporal.value() ) {
+				case DATE:
+					attributes.put( DATETIME_TYPE, "date" );
+					break;
+				case TIME:
+					attributes.put( DATETIME_TYPE, "time" );
+					break;
+				case TIMESTAMP:
+					attributes.put( DATETIME_TYPE, "both" );
+					break;
+				default:
+					throw new UnsupportedOperationException( temporal.value().toString() );
+			}
+		}
+
+		return attributes;
+	}
+}

--- a/modules/java/jakartajpa/src/main/java/org/metawidget/inspector/jakartajpa/JakartaJpaInspectorConfig.java
+++ b/modules/java/jakartajpa/src/main/java/org/metawidget/inspector/jakartajpa/JakartaJpaInspectorConfig.java
@@ -1,0 +1,165 @@
+// Metawidget
+//
+// This file is dual licensed under both the LGPL
+// (http://www.gnu.org/licenses/lgpl-2.1.html) and the EPL
+// (http://www.eclipse.org/org/documents/epl-v10.php). As a
+// recipient of Metawidget, you may choose to receive it under either
+// the LGPL or the EPL.
+//
+// Commercial licenses are also available. See http://metawidget.org
+// for details.
+
+package org.metawidget.inspector.jakartajpa;
+
+import org.metawidget.inspector.impl.BaseObjectInspectorConfig;
+import org.metawidget.inspector.impl.propertystyle.PropertyStyle;
+import org.metawidget.util.simple.ObjectUtils;
+
+/**
+ * Configures a JakartaJpaInspector prior to use. Once instantiated, Inspectors are immutable.
+ *
+ * @author <a href="http://kennardconsulting.com">Richard Kennard</a>
+ */
+
+public class JakartaJpaInspectorConfig
+	extends BaseObjectInspectorConfig {
+
+	//
+	// Private members
+	//
+
+	private boolean	mHideIds		= true;
+
+	private boolean	mHideVersions	= true;
+
+	private boolean	mHideTransients	= false;
+
+	//
+	// Public methods
+	//
+
+	/**
+	 * Sets whether the Inspector returns Id properties as <code>hidden="true"</code>. True by
+	 * default.
+	 * <p>
+	 * JPA recommends using synthetic ids, so generally they don't appear in the UI.
+	 *
+	 * @return this, as part of a fluent interface
+	 */
+
+	public JakartaJpaInspectorConfig setHideIds( boolean hideIds ) {
+
+		mHideIds = hideIds;
+
+		// Fluent interface
+
+		return this;
+	}
+
+	/**
+	 * Sets whether the Inspector returns Version properties as <code>hidden="true"</code>. True by
+	 * default.
+	 * <p>
+	 * JPA uses these as an optimisic locking mechanism, so generally they don't appear in the UI.
+	 *
+	 * @return this, as part of a fluent interface
+	 */
+
+	public JakartaJpaInspectorConfig setHideVersions( boolean hideVersions ) {
+
+		mHideVersions = hideVersions;
+
+		// Fluent interface
+
+		return this;
+	}
+
+	/**
+	 * Sets whether the Inspector returns Transient properties as <code>hidden="true"</code>. False
+	 * by default.
+	 * <p>
+	 * There is not a firm relationship between whether a field should be persisted by JPA, and
+	 * whether it should appear in the UI. Some architectures prefer Transient fields to be hidden
+	 * in the UI by default, but some prefer them to be visible. The latter applies both to
+	 * 'synthetic' fields such as <code>getAge</code> that calculates based off a persisted
+	 * <code>getDateOfBirth</code>, and also to overridden JPA fields (which generally must be
+	 * marked <code>Transient</code> in the subclass).
+	 *
+	 * @return this, as part of a fluent interface
+	 */
+
+	public JakartaJpaInspectorConfig setHideTransients( boolean hideTransients ) {
+
+		mHideTransients = hideTransients;
+
+		// Fluent interface
+
+		return this;
+	}
+
+	/**
+	 * Overridden to return a JpaInspectorConfig, as part of a fluent interface.
+	 */
+
+	@Override
+	public JakartaJpaInspectorConfig setPropertyStyle( PropertyStyle propertyStyle ) {
+
+		return (JakartaJpaInspectorConfig) super.setPropertyStyle( propertyStyle );
+	}
+
+	@Override
+	public boolean equals( Object that ) {
+
+		if ( this == that ) {
+			return true;
+		}
+
+		if ( !ObjectUtils.nullSafeClassEquals( this, that ) ) {
+			return false;
+		}
+
+		if ( mHideIds != ( (JakartaJpaInspectorConfig) that ).mHideIds ) {
+			return false;
+		}
+
+		if ( mHideVersions != ( (JakartaJpaInspectorConfig) that ).mHideVersions ) {
+			return false;
+		}
+
+		if ( mHideTransients != ( (JakartaJpaInspectorConfig) that ).mHideTransients ) {
+			return false;
+		}
+
+		return super.equals( that );
+	}
+
+	@Override
+	public int hashCode() {
+
+		int hashCode = super.hashCode();
+		hashCode = 31 * hashCode + ObjectUtils.nullSafeHashCode( mHideIds );
+		hashCode = 31 * hashCode + ObjectUtils.nullSafeHashCode( mHideVersions );
+		hashCode = 31 * hashCode + ObjectUtils.nullSafeHashCode( mHideTransients );
+
+		return hashCode;
+	}
+
+	//
+	// Protected methods
+	//
+
+	protected boolean isHideIds() {
+
+		return mHideIds;
+	}
+
+	protected boolean isHideVersions() {
+
+		return mHideVersions;
+	}
+
+	protected boolean isHideTransients() {
+
+		return mHideTransients;
+	}
+}

--- a/modules/java/jakartajpa/src/main/java/org/metawidget/inspector/jakartajpa/package-info.java
+++ b/modules/java/jakartajpa/src/main/java/org/metawidget/inspector/jakartajpa/package-info.java
@@ -1,0 +1,18 @@
+// Metawidget
+//
+// This file is dual licensed under both the LGPL
+// (http://www.gnu.org/licenses/lgpl-2.1.html) and the EPL
+// (http://www.eclipse.org/org/documents/epl-v10.php). As a
+// recipient of Metawidget, you may choose to receive it under either
+// the LGPL or the EPL.
+//
+// Commercial licenses are also available. See http://metawidget.org
+// for details.
+
+/**
+ * Inspectors: JPA annotations support.
+ *
+ * @author <a href="http://kennardconsulting.com">Richard Kennard</a>
+ */
+
+package org.metawidget.inspector.jakartajpa;

--- a/modules/java/jakartajpa/src/test/java/org/metawidget/inspector/jakartajpa/JakartaJpaInspectorTest.java
+++ b/modules/java/jakartajpa/src/test/java/org/metawidget/inspector/jakartajpa/JakartaJpaInspectorTest.java
@@ -1,0 +1,274 @@
+// Metawidget
+//
+// This file is dual licensed under both the LGPL
+// (http://www.gnu.org/licenses/lgpl-2.1.html) and the EPL
+// (http://www.eclipse.org/org/documents/epl-v10.php). As a
+// recipient of Metawidget, you may choose to receive it under either
+// the LGPL or the EPL.
+//
+// Commercial licenses are also available. See http://metawidget.org
+// for details.
+
+package org.metawidget.inspector.jakartajpa;
+
+import static org.metawidget.inspector.InspectionResultConstants.*;
+
+import java.util.Date;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import jakarta.persistence.Transient;
+import jakarta.persistence.Version;
+
+import junit.framework.TestCase;
+
+import org.metawidget.inspector.impl.propertystyle.javabean.JavaBeanPropertyStyle;
+import org.metawidget.inspector.impl.propertystyle.javabean.JavaBeanPropertyStyleConfig;
+import org.metawidget.util.MetawidgetTestUtils;
+import org.metawidget.util.XmlUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * @author <a href="http://kennardconsulting.com">Richard Kennard</a>
+ */
+
+public class JakartaJpaInspectorTest
+	extends TestCase {
+
+	//
+	// Public methods
+	//
+
+	public void testInspection() {
+
+		JakartaJpaInspector inspector = new JakartaJpaInspector( new JakartaJpaInspectorConfig().setPropertyStyle( new JavaBeanPropertyStyle( new JavaBeanPropertyStyleConfig().setSupportPublicFields( true ) ) ) );
+		Document document = XmlUtils.documentFromString( inspector.inspect( new Foo(), Foo.class.getName() ) );
+
+		assertEquals( "inspection-result", document.getFirstChild().getNodeName() );
+
+		// Entity
+
+		Element entity = (Element) document.getDocumentElement().getFirstChild();
+		assertEquals( ENTITY, entity.getNodeName() );
+		assertEquals( Foo.class.getName(), entity.getAttribute( TYPE ) );
+		assertFalse( entity.hasAttribute( NAME ) );
+
+		// Properties
+
+		Element property = XmlUtils.getChildWithAttributeValue( entity, NAME, "id" );
+		assertEquals( PROPERTY, property.getNodeName() );
+		assertEquals( TRUE, property.getAttribute( HIDDEN ) );
+		assertFalse( property.hasAttribute( MAXIMUM_LENGTH ) );
+		assertEquals( property.getAttributes().getLength(), 2 );
+
+		property = XmlUtils.getChildWithAttributeValue( entity, NAME, "embeddedId" );
+		assertEquals( PROPERTY, property.getNodeName() );
+		assertEquals( TRUE, property.getAttribute( HIDDEN ) );
+		assertFalse( property.hasAttribute( MAXIMUM_LENGTH ) );
+		assertEquals( property.getAttributes().getLength(), 2 );
+
+		property = XmlUtils.getChildWithAttributeValue( entity, NAME, "bar" );
+		assertEquals( PROPERTY, property.getNodeName() );
+		assertEquals( TRUE, property.getAttribute( REQUIRED ) );
+		assertEquals( "10", property.getAttribute( MAXIMUM_LENGTH ) );
+		assertEquals( property.getAttributes().getLength(), 3 );
+
+		property = XmlUtils.getChildWithAttributeValue( entity, NAME, "bar1" );
+		assertEquals( PROPERTY, property.getNodeName() );
+		assertEquals( "20", property.getAttribute( MAXIMUM_LENGTH ) );
+		assertEquals( property.getAttributes().getLength(), 2 );
+
+		property = XmlUtils.getChildWithAttributeValue( entity, NAME, "baz" );
+		assertEquals( PROPERTY, property.getNodeName() );
+		assertEquals( TRUE, property.getAttribute( LARGE ) );
+		assertEquals( TRUE, property.getAttribute( REQUIRED ) );
+		assertEquals( property.getAttributes().getLength(), 3 );
+
+		property = XmlUtils.getChildWithAttributeValue( entity, NAME, "date" );
+		assertEquals( PROPERTY, property.getNodeName() );
+		assertEquals( "date", property.getAttribute( DATETIME_TYPE ) );
+		assertEquals( property.getAttributes().getLength(), 2 );
+
+		property = XmlUtils.getChildWithAttributeValue( entity, NAME, "time" );
+		assertEquals( PROPERTY, property.getNodeName() );
+		assertEquals( "time", property.getAttribute( DATETIME_TYPE ) );
+		assertEquals( property.getAttributes().getLength(), 2 );
+
+		property = XmlUtils.getChildWithAttributeValue( entity, NAME, "datetime" );
+		assertEquals( PROPERTY, property.getNodeName() );
+		assertEquals( "both", property.getAttribute( DATETIME_TYPE ) );
+		assertEquals( property.getAttributes().getLength(), 2 );
+
+		property = XmlUtils.getChildWithAttributeValue( entity, NAME, "oneToOne" );
+		assertEquals( PROPERTY, property.getNodeName() );
+		assertEquals( TRUE, property.getAttribute( REQUIRED ) );
+		assertEquals( "foo", property.getAttribute( INVERSE_RELATIONSHIP ) );
+		assertEquals( property.getAttributes().getLength(), 3 );
+
+		property = XmlUtils.getChildWithAttributeValue( entity, NAME, "oneToMany" );
+		assertEquals( PROPERTY, property.getNodeName() );
+		assertEquals( "bar", property.getAttribute( INVERSE_RELATIONSHIP ) );
+		assertEquals( property.getAttributes().getLength(), 2 );
+
+		assertEquals( entity.getChildNodes().getLength(), 11 );
+	}
+
+	public void testHideIds() {
+
+		// Show ids
+
+		JakartaJpaInspectorConfig config = new JakartaJpaInspectorConfig();
+		config.setPropertyStyle( new JavaBeanPropertyStyle( new JavaBeanPropertyStyleConfig().setSupportPublicFields( true ) ) );
+		config.setHideIds( false );
+		JakartaJpaInspector inspector = new JakartaJpaInspector( config );
+		Document document = XmlUtils.documentFromString( inspector.inspect( new Foo(), Foo.class.getName() ) );
+
+		assertEquals( "inspection-result", document.getFirstChild().getNodeName() );
+		Element entity = (Element) document.getDocumentElement().getFirstChild();
+
+		assertEquals( XmlUtils.getChildWithAttributeValue( entity, NAME, "id" ), null );
+		assertEquals( XmlUtils.getChildWithAttributeValue( entity, NAME, "embeddedId" ), null );
+
+		// Hidden by default
+
+		config = new JakartaJpaInspectorConfig();
+		config.setPropertyStyle( new JavaBeanPropertyStyle( new JavaBeanPropertyStyleConfig().setSupportPublicFields( true ) ) );
+		inspector = new JakartaJpaInspector( config );
+		document = XmlUtils.documentFromString( inspector.inspect( new Foo(), Foo.class.getName() ) );
+
+		assertEquals( "inspection-result", document.getFirstChild().getNodeName() );
+		entity = (Element) document.getDocumentElement().getFirstChild();
+
+		Element property = XmlUtils.getChildWithAttributeValue( entity, NAME, "id" );
+		assertEquals( PROPERTY, property.getNodeName() );
+		assertEquals( TRUE, property.getAttribute( HIDDEN ) );
+		assertEquals( property.getAttributes().getLength(), 2 );
+
+		property = XmlUtils.getChildWithAttributeValue( entity, NAME, "embeddedId" );
+		assertEquals( PROPERTY, property.getNodeName() );
+		assertEquals( TRUE, property.getAttribute( HIDDEN ) );
+		assertEquals( property.getAttributes().getLength(), 2 );
+	}
+
+	public void testHideVersions() {
+
+		// Show versions
+
+		JakartaJpaInspectorConfig config = new JakartaJpaInspectorConfig();
+		config.setPropertyStyle( new JavaBeanPropertyStyle( new JavaBeanPropertyStyleConfig().setSupportPublicFields( true ) ) );
+		config.setHideVersions( false );
+		JakartaJpaInspector inspector = new JakartaJpaInspector( config );
+		Document document = XmlUtils.documentFromString( inspector.inspect( new Foo(), Foo.class.getName() ) );
+
+		assertEquals( "inspection-result", document.getFirstChild().getNodeName() );
+		Element entity = (Element) document.getDocumentElement().getFirstChild();
+
+		assertEquals( XmlUtils.getChildWithAttributeValue( entity, NAME, "version" ), null );
+
+		// Hidden by default
+
+		config = new JakartaJpaInspectorConfig();
+		config.setPropertyStyle( new JavaBeanPropertyStyle( new JavaBeanPropertyStyleConfig().setSupportPublicFields( true ) ) );
+		inspector = new JakartaJpaInspector( config );
+		document = XmlUtils.documentFromString( inspector.inspect( new Foo(), Foo.class.getName() ) );
+
+		assertEquals( "inspection-result", document.getFirstChild().getNodeName() );
+		entity = (Element) document.getDocumentElement().getFirstChild();
+
+		Element property = XmlUtils.getChildWithAttributeValue( entity, NAME, "version" );
+		assertEquals( PROPERTY, property.getNodeName() );
+		assertEquals( TRUE, property.getAttribute( HIDDEN ) );
+		assertEquals( property.getAttributes().getLength(), 2 );
+	}
+
+	public void testHideTransients() {
+
+		// Hide transient
+
+		JakartaJpaInspectorConfig config = new JakartaJpaInspectorConfig();
+		config.setPropertyStyle( new JavaBeanPropertyStyle( new JavaBeanPropertyStyleConfig().setSupportPublicFields( true ) ) );
+		config.setHideTransients( true );
+		JakartaJpaInspector inspector = new JakartaJpaInspector( config );
+		Document document = XmlUtils.documentFromString( inspector.inspect( new Foo(), Foo.class.getName() ) );
+
+		assertEquals( "inspection-result", document.getFirstChild().getNodeName() );
+		Element entity = (Element) document.getDocumentElement().getFirstChild();
+
+		Element property = XmlUtils.getChildWithAttributeValue( entity, NAME, "transient1" );
+		assertEquals( PROPERTY, property.getNodeName() );
+		assertEquals( TRUE, property.getAttribute( HIDDEN ) );
+		assertEquals( property.getAttributes().getLength(), 2 );
+
+		// Shown by default
+
+		config = new JakartaJpaInspectorConfig();
+		config.setPropertyStyle( new JavaBeanPropertyStyle( new JavaBeanPropertyStyleConfig().setSupportPublicFields( true ) ) );
+		inspector = new JakartaJpaInspector( config );
+		document = XmlUtils.documentFromString( inspector.inspect( new Foo(), Foo.class.getName() ) );
+
+		assertEquals( "inspection-result", document.getFirstChild().getNodeName() );
+		entity = (Element) document.getDocumentElement().getFirstChild();
+
+		assertEquals( XmlUtils.getChildWithAttributeValue( entity, NAME, "transient1" ), null );
+	}
+
+	public void testConfig() {
+
+		MetawidgetTestUtils.testEqualsAndHashcode( JakartaJpaInspectorConfig.class, new JakartaJpaInspectorConfig() {
+			// Subclass
+		} );
+	}
+
+	//
+	// Inner class
+	//
+
+	public static class Foo {
+
+		@Id
+		@Column
+		public String	id;
+
+		@EmbeddedId
+		public String	embeddedId;
+
+		@Version
+		public String	version;
+
+		@Column( nullable = false, length = 10 )
+		public String	bar;
+
+		@Column( length = 20 )
+		public String	bar1;
+
+		@Lob
+		@ManyToOne( optional = false )
+		public String	baz;
+
+		@Transient
+		public String	transient1;
+
+		@Temporal( TemporalType.DATE )
+		public Date		date;
+
+		@Temporal( TemporalType.TIME )
+		public Date		time;
+
+		@Temporal( TemporalType.TIMESTAMP )
+		public Date		datetime;
+
+		@OneToOne( optional = false, mappedBy = "foo" )
+		public String	oneToOne;
+
+		@OneToMany( mappedBy = "bar" )
+		public String	oneToMany;
+	}
+}

--- a/modules/java/pom.xml
+++ b/modules/java/pom.xml
@@ -32,6 +32,7 @@
 		<module>jackson</module>
 		<module>jbpm</module>
 		<module>jpa</module>
+		<module>jakartajpa</module>
 		<module>json</module>
 		<module>jsp</module>
 		<module>miglayout</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1198,8 +1198,8 @@
 				<version>2.3.2</version>
 				<!-- Metawidget requires JDK 1.5+ -->
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>25</source>
+					<target>25</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Changed the imports from javax to jakarta, renamed files to follow suit.
Java 1.5 no longer available(!). I used Java 25 as it's what I had; you might want Java 17 or 21 instead, if last year's Java 25 is too modern.